### PR TITLE
Dev

### DIFF
--- a/chat_commands.lua
+++ b/chat_commands.lua
@@ -526,6 +526,26 @@ local cozymode = {
 	end,
 }
 
+local cozybrushsettings = {
+	description = "Invoke Light Brush settings formspec.",
+	privs = { interact = true },
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if not player then
+			return false
+		end
+		local itemstack = player:get_wielded_item()
+		if itemstack:get_name() ~= "cozylights:light_brush" then
+			return false, "Equip a Light Brush to open its settings."
+		end
+		cozylights:show_brush_settings(name, itemstack)
+		return true, "UI dispatched."
+	end,
+}
+
+minetest.register_chatcommand("cozybrushsettings", cozybrushsettings)
+minetest.register_chatcommand("zbs", cozybrushsettings)
+
 minetest.register_chatcommand("clearlights", clearlights)
 minetest.register_chatcommand("zcl", clearlights)
 

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 cozylights = {
 	-- constant size values and tables
-	version = "0.3.2",
+	version = "0.3.3",
 	default_size = tonumber(minetest.settings:get("mapfix_default_size")) or 40,
 	global_brightness = tonumber(minetest.settings:get("cozylights_global_brightness")) or 12,
 	global_radius = tonumber(minetest.settings:get("cozylights_global_radius")) or 15,
@@ -300,6 +300,8 @@ end
 
 local hash_pos = cozylights.hash_pos
 
+local mod_storage = minetest.get_mod_storage()
+
 minetest.register_on_joinplayer(function(player)
 	if not player then
 		return
@@ -307,54 +309,63 @@ minetest.register_on_joinplayer(function(player)
 	local pos = vector.round(player:get_pos())
 	pos.y = pos.y + 1
 	cozylights:on_join_cleanup(pos, 30)
-	local meta = player:get_meta()
-	if meta:get_int("cozylights_manual_issued") == 0 then
+	local player_name = player:get_player_name()
+	local manual_flag = "issued_manual_" .. player_name
+	if mod_storage:get_int(manual_flag) == 0 then
 		local inv = player:get_inventory()
 		if inv:room_for_item("main", "cozylights:alpha_manual") then
 			inv:add_item("main", "cozylights:alpha_manual")
-			meta:set_int("cozylights_manual_issued", 1)
+			mod_storage:set_int(manual_flag, 1)
 		else
 			minetest.log(
 				"warning",
-				"[cozylights] Failed to issue alpha manual to " .. player:get_player_name() .. " - Inventory saturated."
+				"[cozylights] Failed to issue alpha manual to " .. player_name .. " - Inventory saturated."
 			)
 		end
 	end
-	cozylights.cozyplayers[player:get_player_name()] = {
-		name = player:get_player_name(),
-		pos_hash = hash_pos(pos),
+	local meta = player:get_meta()
+	local hist_str = meta:get_string("cozylights_lbrush_history")
+	local lbrush_history = {}
+	if hist_str and hist_str ~= "" then
+		lbrush_history = minetest.deserialize(hist_str) or {}
+	end
+	cozylights.cozyplayers[player_name] = {
+		name = player_name,
+		pos_hash = cozylights.hash_pos(pos),
 		wielded_item = 0,
 		last_pos = pos,
 		last_wield = "",
 		prev_wielded_lights = {},
-		lbrush = {
-			brightness = 14,
-			radius = 80,
-			strength = 0.5,
-			mode = 1,
-			cover_only_surfaces = 0,
-			pos_hash = 0,
-		},
+		lbrush_history = lbrush_history,
 	}
 end)
+
 minetest.register_on_leaveplayer(function(player)
 	if not player then
 		return
 	end
 	local name = player:get_player_name()
-	for i = 1, #cozylights.cozyplayers do
-		if cozylights.cozyplayers[i].name == name then
-			cozylights:wielded_light_cleanup(player, cozylights.cozyplayers[i], 30)
-			table.remove(cozylights.cozyplayers, i)
+	local cozyplayer = cozylights.cozyplayers[name]
+	if cozyplayer then
+		if cozyplayer.lbrush_history then
+			local meta = player:get_meta()
+			meta:set_string("cozylights_lbrush_history", minetest.serialize(cozyplayer.lbrush_history))
 		end
+		cozylights:remove_wield_hud(player, cozyplayer)
+		cozylights:wielded_light_cleanup(player, cozyplayer, 30)
+		cozylights.cozyplayers[name] = nil
 	end
 end)
 
 minetest.register_on_shutdown(function()
-	for i = 1, #cozylights.cozyplayers do
-		local player = minetest.get_player_by_name(cozylights.cozyplayers[i].name)
-		if player ~= nil then
-			cozylights:wielded_light_cleanup(player, cozylights.cozyplayers[i], 30)
+	for name, cozyplayer in pairs(cozylights.cozyplayers) do
+		local player = minetest.get_player_by_name(name)
+		if player then
+			if cozyplayer.lbrush_history then
+				local meta = player:get_meta()
+				meta:set_string("cozylights_lbrush_history", minetest.serialize(cozyplayer.lbrush_history))
+			end
+			cozylights:wielded_light_cleanup(player, cozyplayer, 30)
 		end
 	end
 end)
@@ -511,7 +522,8 @@ local function on_brush_hold(player, cozyplayer, pos, t)
 	if control_bits < 128 or control_bits >= 256 then
 		return
 	end
-	local lb = cozyplayer.lbrush
+	local itemstack = player:get_wielded_item()
+	local lb = cozylights:get_brush_settings(itemstack, cozyplayer.name)
 	if lb.radius > 10 then
 		return
 	end
@@ -528,18 +540,12 @@ local function on_brush_hold(player, cozyplayer, pos, t)
 		above.y = above.y - 1
 	end
 	local above_hash = hash_pos(above)
-	if above_hash ~= lb.pos_hash or lb.mode == 2 or lb.mode == 4 or lb.mode == 5 then
-		lb.pos_hash = above_hash
+	if above_hash ~= cozyplayer.last_brush_hash or lb.mode == 2 or lb.mode == 4 or lb.mode == 5 then
+		cozyplayer.last_brush_hash = above_hash
 		cozylights:draw_brush_light(above, lb)
 		local exe_time = os.clock() - t
 		total_brush_hold_time = total_brush_hold_time + mf(exe_time * 1000)
 		total_brush_hold_step_count = total_brush_hold_step_count + 1
-		print(
-			"Av cozy lights brush step time "
-				.. mf(total_brush_hold_time / total_brush_hold_step_count)
-				.. " ms. Sample of: "
-				.. total_brush_hold_step_count
-		)
 		--if exe_time > brush_hold_step then
 		--	minetest.chat_send_all("brush hold step was adjusted to "..(exe_time*2).." secs to help crispy potato.")
 		--	brush_hold_step = exe_time*2
@@ -551,9 +557,27 @@ cozylights.uncozy_chunk_queue = {}
 cozylights.uncozy_queue_idx = 1
 local UNCOZY_CHUNK_RAD = 16
 local UNCOZY_STEP = UNCOZY_CHUNK_RAD * 2
+local hud_dtime = 0
+local hud_step = 0.25
 
 cozylights.drawn_nodes = {}
 minetest.register_globalstep(function(dtime)
+	hud_dtime = hud_dtime + dtime
+	if hud_dtime >= hud_step then
+		for _, cozyplayer in pairs(cozylights.cozyplayers) do
+			if cozyplayer.hud_timeout and cozyplayer.hud_timeout > 0 then
+				cozyplayer.hud_timeout = cozyplayer.hud_timeout - hud_dtime
+				if cozyplayer.hud_timeout <= 0 then
+					local player = minetest.get_player_by_name(cozyplayer.name)
+					if player then
+						cozylights:remove_wield_hud(player, cozyplayer)
+					end
+					cozyplayer.hud_timeout = 0
+				end
+			end
+		end
+		hud_dtime = 0
+	end
 	if wield_light_enabled then
 		wield_dtime = wield_dtime + dtime
 		if wield_dtime > wield_step then
@@ -618,13 +642,30 @@ minetest.register_globalstep(function(dtime)
 		for _, cozyplayer in pairs(cozylights.cozyplayers) do
 			local t = os.clock()
 			local player = minetest.get_player_by_name(cozyplayer.name)
+			if not player then
+				goto skip_hud
+			end
 			local pos = vector.round(player:get_pos())
 			pos.y = pos.y + 1
-			local wield_name = player:get_wielded_item():get_name()
-			--todo: checking against a string is expensive, what do
+			local itemstack = player:get_wielded_item()
+			local wield_name = itemstack:get_name()
+			local wield_index = player:get_wield_index() -- Retrieve hotbar pointer
 			if wield_name == "cozylights:light_brush" then
+				if not cozyplayer.wielding_brush or cozyplayer.last_wield_index ~= wield_index then
+					cozyplayer.wielding_brush = true
+					cozyplayer.last_wield_index = wield_index
+					cozylights:update_wield_hud(player, cozyplayer, itemstack, 3.0)
+				end
 				on_brush_hold(player, cozyplayer, pos, t)
+			else
+				if cozyplayer.wielding_brush then
+					cozylights:remove_wield_hud(player, cozyplayer)
+					cozyplayer.wielding_brush = false
+					cozyplayer.last_wield_index = nil
+					cozyplayer.hud_timeout = 0
+				end
 			end
+			::skip_hud::
 		end
 	end
 	on_gen_dtime = on_gen_dtime + dtime

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 cozylights = {
 	-- constant size values and tables
-	version = "0.3.3",
+	version = "0.3.4",
 	default_size = tonumber(minetest.settings:get("mapfix_default_size")) or 40,
 	global_brightness = tonumber(minetest.settings:get("cozylights_global_brightness")) or 12,
 	global_radius = tonumber(minetest.settings:get("cozylights_global_radius")) or 15,

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,6 @@
 cozylights = {
 	-- constant size values and tables
-	version = "0.3.4",
+	version = "0.3.3",
 	default_size = tonumber(minetest.settings:get("mapfix_default_size")) or 40,
 	global_brightness = tonumber(minetest.settings:get("cozylights_global_brightness")) or 12,
 	global_radius = tonumber(minetest.settings:get("cozylights_global_radius")) or 15,

--- a/light_brush.lua
+++ b/light_brush.lua
@@ -1,46 +1,31 @@
 local mf = math.floor
 local hash_pos = cozylights.hash_pos
 
-local function on_secondary_use(user)
-	local lb = cozylights.cozyplayers[user:get_player_name()].lbrush
+function cozylights:show_brush_settings(player_name, itemstack)
+	local lb = cozylights:get_brush_settings(itemstack, player_name)
 	local settings_formspec = {
 		"formspec_version[4]",
-		--"size[6,6.4]",
 		"size[5.2,5]",
 		"label[1.45,0.5;Light Brush Settings]",
 
 		"label[0.95,1.35;Radius]",
 		"field[3.6,1.1;0.7,0.5;radius;;" .. lb.radius .. "]",
-		"tooltip[0.95,1.1;3.4,0.5;If radius is 0 then only one node will be affected by the brush.\n"
-			.. "If not zero then it's a sphere of affected nodes with specified radius.\n"
-			.. "As of now max radius is only 120.\n"
-			.. "With radiuses over 30 mouse hold as of now does not work, only point and click]",
+		"tooltip[0.95,1.1;3.4,0.5;If radius is 0 then only one node will be affected by the brush.\nIf not zero then it's a sphere of affected nodes with specified radius.\nAs of now max radius is only 120.\nWith radiuses over 30 mouse hold as of now does not work, only point and click]",
 
 		"label[0.95,2.05;Brightness]",
 		"field[3.6,1.8;0.7,0.5;brightness;;" .. lb.brightness .. "]",
-		"tooltip[0.95,1.8;3.4,0.5;Brightness - for most brush modes values are from 1 to 14, corresponding to engine light levels.\n"
-			.. "If brush mode is 'darken' or 'override' then 0 will replace lowest light levels with air.]",
+		"tooltip[0.95,1.8;3.4,0.5;Brightness - for most brush modes values are from 1 to 14, corresponding to engine light levels.\nIf brush mode is 'darken' or 'override' then 0 will replace lowest light levels with air.]",
 
 		"label[0.95,2.75;Strength]",
 		"field[3.6,2.5;0.7,0.5;strength;;" .. lb.strength .. "]",
-		"tooltip[0.95,2.5;3.4,0.5;Strength, can be from 0 to 1, decimal values of any precision are valid.\n"
-			.. "Determines how bright(relative to brightness setting) light nodes in affected area will be.]",
+		"tooltip[0.95,2.5;3.4,0.5;Strength, can be from 0 to 1, decimal values of any precision are valid.\nDetermines how bright(relative to brightness setting) light nodes in affected area will be.]",
 
 		"label[0.95,3.45;Brush Mode]",
 		"dropdown[2.8,3.2;1.5,0.5;mode;default,erase,override,lighten,darken,blend;" .. lb.mode .. "]",
-		"tooltip[0.95,3.2;3.4,0.5;\nDefault - replace only dimmer light nodes or air with brush.\n\n"
-			.. "Erase - inverse of default, replaces only lighter nodes with darker nodes or air if brightness is 0.\n\n"
-			.. "Override - set light nodes as brush settings dictate regardless of difference in brigthness.\n\n"
-			.. "Lighten - milder than default mode.\n\n"
-			.. "Darken - milder erase, does not darken below light 1(does not replace with air).\n\n"
-			.. "Blend - blend affected nodes' brigthness with brush brigthness.\n"
-			.. "Even though behaves correctly, as of now looks weird and unintuitive if radius is not 0.]",
-		--"checkbox[1.7,4.6;cover_only_surfaces;cover only surfaces;"..(lb.cover_only_surfaces == 1 and "true" or "false").."]",
-		--"tooltip[1.7,4.4;2.6,0.4;if enabled brush will not fill up the air with light above the ground;"..bgcolor..";#FFFFFF]",
-		--"button_exit[1,5.1;4,0.8;confirm;Confirm]",
+		"tooltip[0.95,3.2;3.4,0.5;\nDefault - replace only dimmer light nodes or air with brush.\n\nErase - inverse of default, replaces only lighter nodes with darker nodes or air if brightness is 0.\n\nOverride - set light nodes as brush settings dictate regardless of difference in brigthness.\n\nLighten - milder than default mode.\n\nDarken - milder erase, does not darken below light 1(does not replace with air).\n\nBlend - blend affected nodes' brigthness with brush brigthness.\nEven though behaves correctly, as of now looks weird and unintuitive if radius is not 0.]",
 		"button_exit[1.1,4;3,0.8;confirm;Confirm]",
 	}
-	minetest.show_formspec(user:get_player_name(), "cozylights:brush_settings", table.concat(settings_formspec, ""))
+	minetest.show_formspec(player_name, "cozylights:brush_settings", table.concat(settings_formspec, ""))
 end
 
 minetest.register_tool("cozylights:light_brush", {
@@ -56,63 +41,98 @@ minetest.register_tool("cozylights:light_brush", {
 		if pointed_thing.under then
 			local nodenameunder = cozylights.get_node(pointed_thing.under).name
 			local nodedefunder = minetest.registered_nodes[nodenameunder]
-			local lb = cozylights.cozyplayers[user:get_player_name()].lbrush
+			local name = user:get_player_name()
+			local lb = cozylights:get_brush_settings(itemstack, name)
 			local above = pointed_thing.above
 			if nodenameunder ~= "air" and nodedefunder.buildable_to == true then
 				above.y = above.y - 1
 			end
+			local cp = cozylights.cozyplayers[name]
 			local above_hash = hash_pos(above)
-			lb.pos_hash = above_hash
+			if cp then
+				cp.last_brush_hash = above_hash
+			end
 			cozylights:draw_brush_light(pointed_thing.above, lb)
 		end
+		return itemstack
 	end,
-	on_place = function(_, placer)
-		on_secondary_use(placer)
+	on_place = function(itemstack, placer, pointed_thing)
+		local name = placer:get_player_name()
+		if cozylights:undo_last_brush(name) then
+			minetest.chat_send_player(name, "Light map reverted.")
+		else
+			minetest.chat_send_player(name, "Brush history is empty.")
+		end
+		return itemstack
 	end,
-	on_secondary_use = function(_, user)
-		on_secondary_use(user)
+	on_secondary_use = function(itemstack, user, pointed_thing)
+		local name = user:get_player_name()
+		if cozylights:undo_last_brush(name) then
+			minetest.chat_send_player(name, "Light map reverted.")
+		else
+			minetest.chat_send_player(name, "Brush history is empty.")
+		end
+		return itemstack
 	end,
 	sound = { breaks = "default_tool_breaks" },
 })
 
 minetest.register_on_player_receive_fields(function(player, formname, fields)
-	if formname ~= "cozylights:brush_settings" then
+	if formname ~= "cozylights:brush_settings" or not player then
 		return
 	end
-	if player == nil then
+	local itemstack = player:get_wielded_item()
+	if itemstack:get_name() ~= "cozylights:light_brush" then
+		minetest.chat_send_player(player:get_player_name(), "Settings closed: tool context lost.")
 		return
 	end
-	local lb = cozylights.cozyplayers[player:get_player_name()].lbrush
+	local meta = itemstack:get_meta()
+	local updated = false
 	if fields.brightness then
-		local brightness = tonumber(fields.brightness) > 14 and 14 or tonumber(fields.brightness)
-		lb.brightness = brightness < 0 and 0 or mf(brightness or 0)
+		meta:set_int("brightness", math.min(14, math.max(0, tonumber(fields.brightness) or 0)))
+		updated = true
 	end
 	if fields.radius then
-		local radius = tonumber(fields.radius) > 200 and 200 or tonumber(fields.radius)
-		lb.radius = radius < 0 and 0 or mf(radius or 0)
+		meta:set_int("radius", math.min(200, math.max(0, tonumber(fields.radius) or 0)))
+		updated = true
 	end
 	if fields.strength then
-		local strength = tonumber(fields.strength) > 1 and 1 or tonumber(fields.strength)
-		lb.strength = strength < 0 and 0 or strength
+		meta:set_float("strength", math.max(0, math.min(1, tonumber(fields.strength) or 0)))
+		updated = true
 	end
 	if fields.mode then
-		local mode = fields.mode
-		local idx = 6
-		if mode == "default" then
-			idx = 1
-		elseif mode == "erase" then
-			idx = 2
-		elseif mode == "override" then
-			idx = 3
-		elseif mode == "lighten" then
-			idx = 4
-		elseif mode == "darken" then
-			idx = 5
-		end
-		lb.mode = idx
+		local mode_map = { default = 1, erase = 2, override = 3, lighten = 4, darken = 5, blend = 6 }
+		meta:set_int("mode", mode_map[fields.mode] or 1)
+		updated = true
 	end
-	if fields.cover_only_surfaces then
-		lb.cover_only_surfaces = fields.cover_only_surfaces == "true" and 1 or 0
+	if updated then
+		local mode_names = { "Default", "Erase", "Override", "Lighten", "Darken", "Blend" }
+		local mode_idx = meta:get_int("mode")
+		local desc = string.format(
+			"Light Brush\nRadius: %d | Brightness: %d\nStrength: %.2f | Mode: %s",
+			meta:get_int("radius"),
+			meta:get_int("brightness"),
+			meta:get_float("strength"),
+			mode_names[mode_idx] or "Default"
+		)
+		meta:set_string("description", desc)
+		local tints = {
+			[1] = "",
+			[2] = "^[colorize:#FF0000:60",
+			[3] = "^[colorize:#00FF00:60",
+			[4] = "^[colorize:#00FFFF:60",
+			[5] = "^[colorize:#000000:80",
+			[6] = "^[colorize:#FF00FF:60",
+		}
+		local base_img = minetest.registered_tools["cozylights:light_brush"].inventory_image
+		local wield_base = minetest.registered_tools["cozylights:light_brush"].wield_image
+		meta:set_string("inventory_image", base_img .. tints[mode_idx])
+		meta:set_string("wield_image", base_img .. tints[mode_idx] .. "^[transformR90")
+		player:set_wielded_item(itemstack)
+		local cp = cozylights.cozyplayers[player:get_player_name()]
+		if cp and cp.hud_active then
+			cozylights:update_wield_hud(player, cp, itemstack, 2)
+		end
 	end
 end)
 
@@ -156,7 +176,6 @@ local function calc_dims_for_brush(brightness, radius, strength, even)
 			dim_levels[i] = brightness
 		end
 	end
-
 	return dim_levels
 end
 
@@ -188,7 +207,6 @@ local function draw_one_node(pos, lb)
 	if brightness == 0 then
 		new_node_name = "air"
 	end
-
 	if node.name == "air" and new_node_name ~= node.name then
 		minetest.set_node(pos, {
 			name = new_node_name,
@@ -243,39 +261,68 @@ function cozylights:draw_brush_light(pos, lb)
 	local t = os.clock()
 	local radius = lb.radius
 	if radius == 0 then
+		if not lb.is_replay and lb.player_name then
+			local hist = cozylights.cozyplayers[lb.player_name].lbrush_history
+			if hist then
+				table.insert(hist, {
+					pos = vector.new(pos),
+					radius = 0,
+					brightness = lb.brightness,
+					strength = lb.strength,
+					mode = lb.mode,
+				})
+				if #hist > 200 then
+					table.remove(hist, 1)
+				end
+			end
+		end
 		draw_one_node(pos, lb)
 		return
 	end
 	local mode = lb.mode
 	local brightness = lb.brightness
 	local dim_levels = calc_dims_for_brush(brightness, radius, lb.strength, mode == 2 and true or false)
-	print("dim_levels:" .. cozylights:dump(dim_levels))
 	local vm = cozylights.get_voxel_manip()
 	local emin, emax = vm:read_from_map(vector.subtract(pos, radius + 1), vector.add(pos, radius + 1))
 	local data = vm:get_data()
 	local param2data = vm:get_param2_data()
-	local a = VoxelArea:new({
-		MinEdge = emin,
-		MaxEdge = emax,
-	})
+	local a = VoxelArea:new({ MinEdge = emin, MaxEdge = emax })
 	local sphere_surface = cozylights:get_sphere_surface(radius)
 	local ylvl = 1
-	local cid = data[a:index(pos.x, pos.y - 1, pos.z)]
-	local cida = data[a:index(pos.x, pos.y + 1, pos.z)]
-	local c_light_debug14 = c_lights[14] + 14
-	if cid and cida then
-		if
-			(cid == c_air or (cid >= c_lights[1] and cid <= c_light_debug14))
-			and cida ~= c_air
-			and (cida < c_lights[1] or cida > c_light_debug14)
-		then
-			ylvl = -1
-		end
+	if lb.is_replay then
+		ylvl = 0
 	else
-		return
+		local cid = data[a:index(pos.x, pos.y - 1, pos.z)]
+		local cida = data[a:index(pos.x, pos.y + 1, pos.z)]
+		local c_light_debug14 = c_lights[14] + 14
+		if cid and cida then
+			if
+				(cid == c_air or (cid >= c_lights[1] and cid <= c_light_debug14))
+				and cida ~= c_air
+				and (cida < c_lights[1] or cida > c_light_debug14)
+			then
+				ylvl = -1
+			end
+		else
+			return
+		end
 	end
 	pos.y = pos.y + ylvl
-
+	if not lb.is_replay and lb.player_name then
+		local hist = cozylights.cozyplayers[lb.player_name].lbrush_history
+		if hist then
+			table.insert(hist, {
+				pos = vector.new(pos),
+				radius = radius,
+				brightness = brightness,
+				strength = lb.strength,
+				mode = mode,
+			})
+			if #hist > 200 then
+				table.remove(hist, 1)
+			end
+		end
+	end
 	if mode == 1 then
 		if cozylights.always_fix_edges == true then
 			local visited_pos = {}
@@ -440,4 +487,132 @@ function cozylights:draw_brush_light(pos, lb)
 	gent_total = gent_total + mf((os.clock() - t) * 1000)
 	gent_count = gent_count + 1
 	print("Av draw time " .. mf(gent_total / gent_count) .. " ms. Sample of: " .. gent_count)
+end
+
+function cozylights:undo_last_brush(player_name)
+	local cp = cozylights.cozyplayers[player_name]
+	if not cp or not cp.lbrush_history or #cp.lbrush_history == 0 then
+		return false
+	end
+	local stroke = table.remove(cp.lbrush_history)
+	local wipe_rad = stroke.radius + 2
+	local minp = vector.subtract(stroke.pos, wipe_rad)
+	local maxp = vector.add(stroke.pos, wipe_rad)
+	local vm = cozylights.get_voxel_manip()
+	local emin, emax = vm:read_from_map(minp, maxp)
+	local data = vm:get_data()
+	local param2data = vm:get_param2_data()
+	local a = VoxelArea:new({ MinEdge = emin, MaxEdge = emax })
+	local c_air = minetest.get_content_id("air")
+	local c_light1 = minetest.get_content_id("cozylights:light1")
+	local c_light_debug14 = c_light1 + 27
+	for i in a:iterp(minp, maxp) do
+		local cid = data[i]
+		if cid >= c_light1 and cid <= c_light_debug14 then
+			data[i] = c_air
+			param2data[i] = 0
+		end
+	end
+	vm:set_data(data)
+	vm:set_param2_data(param2data)
+	vm:write_to_map()
+	for i = 1, #cp.lbrush_history do
+		local h_stroke = cp.lbrush_history[i]
+		if vector.distance(h_stroke.pos, stroke.pos) <= (h_stroke.radius + wipe_rad) then
+			local lb_replay = {
+				radius = h_stroke.radius,
+				brightness = h_stroke.brightness,
+				strength = h_stroke.strength,
+				mode = h_stroke.mode,
+				is_replay = true,
+			}
+			cozylights:draw_brush_light(vector.new(h_stroke.pos), lb_replay)
+		end
+	end
+	local posrebuilds = {}
+	local tx_locks = {} --prevents duplicates
+	for bound, nodenames in pairs(cozylights.rebuild_bounds) do
+		local search_range = bound + wipe_rad
+		local s_minp = vector.subtract(stroke.pos, search_range)
+		local s_maxp = vector.add(stroke.pos, search_range)
+		local found = cozylights.find_nodes_in_area(s_minp, s_maxp, nodenames)
+		for i = 1, #found do
+			local f_pos = found[i]
+			local f_hash = cozylights.hash_pos(f_pos)
+			if not tx_locks[f_hash] then
+				tx_locks[f_hash] = true
+				posrebuilds[#posrebuilds + 1] = f_pos
+			end
+		end
+	end
+	local single_light_queue = cozylights.single_light_queue
+	local sources_batched = {}
+	for i = 1, #posrebuilds do
+		local source_pos = posrebuilds[i]
+		local f_hash = cozylights.hash_pos(source_pos)
+		local node = cozylights.get_node(source_pos)
+		local cozy_item = cozylights.cozy_items[node.name]
+		if cozy_item then
+			local rebuild_radius, _ = cozylights:calc_dims(node.name, cozy_item)
+			local dist = vector.distance(stroke.pos, source_pos)
+			if dist <= (rebuild_radius + wipe_rad) then
+				cozylights.drawn_nodes[f_hash] = nil
+				cozylights.recently_updated[f_hash] = nil
+				if stroke.radius > 10 then
+					sources_batched[#sources_batched + 1] = { pos = source_pos, cozy_item = cozy_item }
+				else
+					single_light_queue[#single_light_queue + 1] = { pos = source_pos, cozy_item = cozy_item }
+				end
+			end
+		end
+	end
+	if #sources_batched > 0 then
+		cozylights:push_area_queue(minp, maxp, sources_batched)
+	end
+	return true
+end
+
+function cozylights:get_brush_settings(itemstack, player_name)
+	local meta = itemstack:get_meta()
+	return {
+		radius = meta:contains("radius") and meta:get_int("radius") or 3,
+		brightness = meta:contains("brightness") and meta:get_int("brightness") or 5,
+		strength = meta:contains("strength") and meta:get_float("strength") or 0.3,
+		mode = meta:contains("mode") and meta:get_int("mode") or 1,
+		player_name = player_name,
+	}
+end
+
+function cozylights:update_wield_hud(player, cozyplayer, itemstack, duration)
+	local lb = cozylights:get_brush_settings(itemstack, cozyplayer.name)
+	local mode_names = { "Default", "Erase", "Override", "Lighten", "Darken", "Blend" }
+	local hud_text = string.format(
+		"Radius: %d\nBrightness: %d\nStrength: %.2f\nMode: %s",
+		lb.radius,
+		lb.brightness,
+		lb.strength,
+		mode_names[lb.mode] or "Default"
+	)
+	if cozyplayer.hud_id then
+		player:hud_change(cozyplayer.hud_id, "text", hud_text)
+	else
+		cozyplayer.hud_id = player:hud_add({
+			hud_elem_type = "text",
+			position = { x = 0.22, y = 0.5 },
+			name = "cozylights_brush_hud",
+			scale = { x = 90, y = 90 },
+			text = hud_text,
+			number = 0xFFFFFF, -- White hex
+			alignment = { x = 1, y = 0 },
+			offset = { x = 0, y = 0 },
+		})
+	end
+	cozyplayer.hud_timeout = duration or 2.0
+end
+
+function cozylights:remove_wield_hud(player, cozyplayer)
+	if cozyplayer.hud_id then
+		player:hud_remove(cozyplayer.hud_id)
+		cozyplayer.hud_id = nil
+	end
 end

--- a/manual.lua
+++ b/manual.lua
@@ -2,12 +2,15 @@ local manual_content = [[
 <global size=16>
 <center><style color=#F5A623 size=20>CozyLights Alpha Reference</style></center>
 
-<style color=#F52023>Warning: This wasn't supposed to be possible in pure Lua and is a proof-of-concept alpha build full of experiments that may not always work as intended and will be subject to breaking changes.
-In case you are new to unstable Luanti mods, and want to remove this mod from your world, to avoid inconvenience, you have three options:
-1. use unknown_node cleaner mods after cozylights mod is disabled, such as: https://content.luanti.org/packages/AntumDeluge/cleaner/ or https://content.luanti.org/packages/AiTechEye/servercleaner/
-</style>
-2. second option is running /clearlights in areas where cozylights were generated and only then disable the mod, in case you forgot an area, you can reenable the mod to run /clearlights again
+<style color=#F52023>Warning: This wasn't supposed to be possible and is a proof-of-concept alpha build full of experiments that may not always work as intended and will be subject to breaking changes.</style>
+<style color=#F5A623>In case you are new to unstable Luanti mods, and want to remove this mod from your world, to avoid inconvenience, you have three options:
+1. run /clearlights in areas where cozylights were generated and only then disable the mod, in case you forgot an area, you can reenable the mod to run /clearlights again
+2. use unknown_node cleaner mods after cozylights mod is disabled, such as: https://content.luanti.org/packages/AntumDeluge/cleaner/ or https://content.luanti.org/packages/AiTechEye/servercleaner/
 3. use /uncozymode command that runs /clearlights in areas you visit
+
+Important! Light Brush settings where moved to chat command /cozybrushsettings or short version /zbs
+Right click is now undo for light brush history
+</style>
 
 - light_brush is available only in creative. Only default mode for light_brush is being tested, other modes probably work incorrectly after recent changes
 - always_fix_edges is on by default now, which is maybe too expensive for potato. Check cozylights mod settings, the ones that are in Luanti settings
@@ -38,6 +41,8 @@ Changes the engine day_night_ratio for your player. 0 is the darkest night possi
 Changes the brightness of all cozy light nodes by [adjust_by] in the area of [size]. Can be negative. [keep_map] is 1 by default; if the adjustment pushes a node out of the 1-14 bounds, the command safely reverts to preserve the map. Type 0 for [keep_map] if you are okay with breaking the light map.
 <style color=#00FFFF>/uncozymode</style> <style color=#AAAAAA>[number]</style>
 This is when /clearlights is not enough. Stops generating new cozylights and calls clear lights continuously at all players' positions in the area, but slowly overtime, so it wont be realtime, you don't have to wait until the queue catches up with your position, just move around wherever you see cozylights you want to remove. Disable it by typing /cozymode or via /cozysettings.
+<style color=#00FFFF>/cozybrushsettings</style>
+Opens settings for currently equipped light brush.
 <style color=#55FF55 size=18>Shortcuts</style>
 Short versions of commands above:
 <style color=#00FFFF>zcl</style>   - clearlights
@@ -50,7 +55,7 @@ Short versions of commands above:
 <style color=#00FFFF>zs</style>    - cozysettings
 <style color=#00FFFF>zdnr</style>  - daynightratio
 <style color=#00FFFF>za</style>    - cozyadjust
-
+<style color=#00FFFF>zbs</style>    - cozybrushsettings
 More info about how the mod works can be found on contentdb or on the forum.
 Light Excavation Tool 9000 TURBO V3, Consumer Grade Reality Bending Device and Shadow Brush are coming soon!
 ]]

--- a/shared.lua
+++ b/shared.lua
@@ -814,11 +814,9 @@ function cozylights:update_shadow_cone(pos_placed)
 			max_bound = bound
 		end
 	end
-
 	local s_minp = vector.subtract(pos_placed, max_bound)
 	local s_maxp = vector.add(pos_placed, max_bound)
 	local nearby_lights = cozylights.storage.get_lights_in_area(s_minp, s_maxp)
-
 	local occluded_lights = {}
 	for i = 1, #nearby_lights do
 		local l_data = nearby_lights[i]
@@ -833,22 +831,16 @@ function cozylights:update_shadow_cone(pos_placed)
 			end
 		end
 	end
-
 	if #occluded_lights == 0 then
 		return
 	end
-
-	-- Pass 1: Geometry & Bounding
 	local min_read = { x = pos_placed.x, y = pos_placed.y, z = pos_placed.z }
 	local max_read = { x = pos_placed.x, y = pos_placed.y, z = pos_placed.z }
 	local active_casts = {}
 	local VOXEL_SQ_RADIUS = (math.sqrt(3) / 2) ^ 2 * 1.5
-
 	for i = 1, #occluded_lights do
 		local source_pos = occluded_lights[i].pos
 		local radius = occluded_lights[i].radius
-
-		-- Fast API lookup to break VM dependency
 		local node_below = minetest.get_node({ x = source_pos.x, y = source_pos.y - 1, z = source_pos.z }).name
 		local node_above = minetest.get_node({ x = source_pos.x, y = source_pos.y + 1, z = source_pos.z }).name
 		local ylvl = 1
@@ -856,35 +848,26 @@ function cozylights:update_shadow_cone(pos_placed)
 			ylvl = -1
 		end
 		local adj_source = { x = source_pos.x, y = source_pos.y + ylvl, z = source_pos.z }
-
 		local V_a = vector.subtract(pos_placed, adj_source)
 		local D_sq = V_a.x * V_a.x + V_a.y * V_a.y + V_a.z * V_a.z
 		local D = math.sqrt(D_sq)
 		local ux, uy, uz = V_a.x / D, V_a.y / D, V_a.z / D
-
-		-- Dynamic threshold: retain precise overlap heuristic
 		local cos_theta
 		if #occluded_lights == 1 then
 			cos_theta = 1.0 - (VOXEL_SQ_RADIUS / (2 * D_sq))
 		else
 			cos_theta = (D_sq > 3.0) and (math.sqrt(D_sq - 3.0) / D) or -1.0
 		end
-
 		local sphere_surface = cozylights:get_sphere_surface(radius)
 		local valid_targets = {}
-
-		-- Expand VM bounds precisely along the valid cone vectors
 		for j = 1, #sphere_surface do
 			local target = sphere_surface[j]
 			local dot = ux * target.nx + uy * target.ny + uz * target.nz
-
 			if dot >= cos_theta then
 				valid_targets[#valid_targets + 1] = target
-
 				local ex = adj_source.x + target.x
 				local ey = adj_source.y + target.y
 				local ez = adj_source.z + target.z
-
 				min_read.x = math.min(min_read.x, adj_source.x, ex)
 				max_read.x = math.max(max_read.x, adj_source.x, ex)
 				min_read.y = math.min(min_read.y, adj_source.y, ey)
@@ -893,36 +876,27 @@ function cozylights:update_shadow_cone(pos_placed)
 				max_read.z = math.max(max_read.z, adj_source.z, ez)
 			end
 		end
-
 		active_casts[#active_casts + 1] = {
 			adj_source = adj_source,
 			radius = radius,
 			targets = valid_targets,
 		}
 	end
-
 	if #active_casts == 0 then
 		return
 	end
-
-	-- Pad bounds strictly for DDA adjacency logic
 	min_read.x, min_read.y, min_read.z = min_read.x - 1, min_read.y - 1, min_read.z - 1
 	max_read.x, max_read.y, max_read.z = max_read.x + 1, max_read.y + 1, max_read.z + 1
-
-	-- Pass 2: Highly Constrained VoxelManip I/O
 	local vm = cozylights.get_voxel_manip()
 	local emin, emax = vm:read_from_map(min_read, max_read)
 	local data = vm:get_data()
 	local param2data = vm:get_param2_data()
 	local a = VoxelArea:new({ MinEdge = emin, MaxEdge = emax })
-
 	local use_fix_edges = cozylights.always_fix_edges
 	local visited_pos = use_fix_edges and {} or nil
-
 	for i = 1, #active_casts do
 		local cast = active_casts[i]
 		local targets = cast.targets
-
 		for j = 1, #targets do
 			local target = targets[j]
 			local end_pos = {
@@ -931,7 +905,6 @@ function cozylights:update_shadow_cone(pos_placed)
 				z = cast.adj_source.z + target.z,
 			}
 			local dir = vector.direction(cast.adj_source, end_pos)
-
 			if use_fix_edges then
 				cozylights:shadowcast_fix_edges(cast.adj_source, dir, cast.radius, data, param2data, a, pos_placed)
 			else
@@ -939,7 +912,6 @@ function cozylights:update_shadow_cone(pos_placed)
 			end
 		end
 	end
-
 	cozylights:setVoxelManipData(vm, data, param2data, true)
 	print("Shadow cone update time: " .. math.floor((os.clock() - t) * 1000) .. " ms")
 end


### PR DESCRIPTION
- added history for light brush that persists over server reboots, remembers up to 200 last strokes
- now every light brush has its own item metadata that persists over server reboots
- added some basic hud for better ux during swaps of many brushes
- light brush settings were moved to /zbs chat command, right click for light brush is now undo last stroke
- now cozylights reference manual drops to player inventory only once